### PR TITLE
Test Fixes

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -166,7 +166,7 @@ Instructions  can be found in the
 ADB product documentation.
 </a>
 
-In addition to the set of [common parameters](#common-parameters-for-single-resource-providers),
+In addition to the set of [common parameters](#common-parameters-for-resource-providers),
 this provider also supports the parameters listed below.
 <table>
 <thead><tr>
@@ -215,7 +215,7 @@ The Key Vault Username Provider provides Oracle JDBC with a database username
 that is managed by the Key Vault service. This is a Resource Provider
 identified by the name `ojdbc-provider-azure-key-vault-username`.
 
-In addition to the set of [common parameters](#common-parameters-for-single-resource-providers),
+In addition to the set of [common parameters](#common-parameters-for-resource-providers),
 this provider also supports the parameters listed below.
 <table>
 <thead><tr>
@@ -260,7 +260,7 @@ The Key Vault Password Provider provides Oracle JDBC with a database password
 that is managed by the Key Vault service. This is a Resource Provider
 identified by the name `ojdbc-provider-azure-key-vault-password`.
 
-In addition to the set of [common parameters](#common-parameters-for-single-resource-providers),
+In addition to the set of [common parameters](#common-parameters-for-resource-providers),
 this provider also supports the parameters listed below.
 <table>
 <thead><tr>

--- a/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/AzureTokenProviderTest.java
+++ b/ojdbc-provider-azure/src/test/java/oracle/jdbc/provider/azure/resource/AzureTokenProviderTest.java
@@ -217,7 +217,7 @@ public class AzureTokenProviderTest {
   public void testManagedIdentity() {
     Map<String, CharSequence> testParameters = new HashMap<>();
     TestProperties.abortIfNotEqual(AzureTestProperty.AZURE_MANAGED_IDENTITY, "true");
-    testParameters.put("authenticationMethod", "service-principal");
+    testParameters.put("authenticationMethod", "managed-identity");
     verifyAccessToken(testParameters);
   }
 

--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -78,7 +78,6 @@
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc-provider-common</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <type>test-jar</type>
     </dependency>

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProviderTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProviderTest.java
@@ -27,6 +27,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Verifies the {@link OciDatabaseToolsConnectionProvider} as implementing
@@ -94,6 +95,7 @@ public class OciDatabaseToolsConnectionProviderTest {
 
     Arrays.stream(parameters)
       .map(TestProperties::getOptional)
+      .filter(Objects::nonNull)
       .map(ocid -> {
         try {
           return PROVIDER.getConnectionProperties(ocid);

--- a/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProviderTest.java
+++ b/ojdbc-provider-oci/src/test/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProviderTest.java
@@ -19,6 +19,7 @@ import oracle.jdbc.provider.TestProperties;
 import oracle.jdbc.provider.oci.OciTestProperty;
 import oracle.jdbc.spi.OracleConfigurationProvider;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -53,7 +54,10 @@ public class OciDatabaseToolsConnectionProviderTest {
       /* Create a database client */
       dbClient = DatabaseClient.builder().build(provider);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      // This test may be run in an environment having no OCI configuration
+      // file. Don't fail the test suite by throwing an exception, just print
+      // the error message for awareness of users.
+      System.out.println(e.getMessage());
     }
   }
 
@@ -166,6 +170,10 @@ public class OciDatabaseToolsConnectionProviderTest {
       String OCI_USERNAME, String OCI_PASSWORD_OCID, String OCI_DISPLAY_NAME,
       String OCI_COMPARTMENT_ID, String OCI_DATABASE_CONNECTION_STRING,
       String OCI_DATABASE_OCID) {
+
+    // Ignore this test if the required configuration is missing.
+    Assumptions.assumeTrue(client != null);
+
     /* Create a request and dependent object(s). */
     CreateDatabaseToolsConnectionDetails createDatabaseToolsConnectionDetails = CreateDatabaseToolsConnectionOracleDatabaseDetails
         .builder()
@@ -203,6 +211,9 @@ public class OciDatabaseToolsConnectionProviderTest {
    */
   private DeleteDatabaseToolsConnectionResponse sendDeleteConnRequest(
       String ocid) {
+    // Ignore this test if the required configuration is missing.
+    Assumptions.assumeTrue(client != null);
+
     /* Create a request and dependent object(s). */
     DeleteDatabaseToolsConnectionRequest deleteDatabaseToolsConnectionRequest = DeleteDatabaseToolsConnectionRequest
         .builder()
@@ -221,6 +232,9 @@ public class OciDatabaseToolsConnectionProviderTest {
    * @return GetDatabaseToolsConnectionResponse
    */
   private GetDatabaseToolsConnectionResponse sendGetConnRequest(String ocid) {
+    // Ignore this test if the required configuration is missing.
+    Assumptions.assumeTrue(client != null);
+
     /* Create a request and dependent object(s). */
     GetDatabaseToolsConnectionRequest getDatabaseToolsConnectionRequest = GetDatabaseToolsConnectionRequest
         .builder()
@@ -243,6 +257,10 @@ public class OciDatabaseToolsConnectionProviderTest {
   @Test
   private String getConnectionStringFromAutonomousDatabase(
       String OCI_DATABASE_OCID) {
+
+    // Ignore this test if the required configuration is missing.
+    Assumptions.assumeTrue(dbClient != null);
+
     /* Create a request and dependent object(s). */
     GetAutonomousDatabaseRequest getAutonomousDatabaseRequest = GetAutonomousDatabaseRequest
         .builder()

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc-provider-common</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <classifier>tests</classifier>
         <type>test-jar</type>
         <scope>test</scope>


### PR DESCRIPTION
Resolving some issues I found when testing.
- The ojdbc-provider-common test jar dependency had a now non-existent SNAPSHOT version in a few poms. I've made the version the same as the project version.
- README had an incorrect URL for common resource provider parameters.
- An Azure access token provider test for managed identity did not configure managed identity.
- A database tools test would fail test runs if no configuration file was present. It will now just indicate that the test was skipped and ignored.
- A database tools test would NPE if required test.properties were missing. It will now be a no-op.