### PR TITLE
add LICENSE.txt and THIRD_PARTY_LICENSE.txt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,5 +126,23 @@
         </executions>
       </plugin>
     </plugins>
+    <resources>
+      <!-- Add THIRD_PARTY_LICENSES.txt from the basedir of each module -->
+      <resource>
+        <directory>${project.basedir}</directory>
+        <includes>
+          <include>THIRD_PARTY_LICENSES.txt</include>
+        </includes>
+        <targetPath>META-INF</targetPath>
+      </resource>
+      <!-- Add LICENSE.txt from the root directory -->
+      <resource>
+        <directory>${project.basedir}/..</directory>
+        <includes>
+          <include>LICENSE.txt</include>
+        </includes>
+        <targetPath>META-INF</targetPath>
+      </resource>
+    </resources>
   </build>
 </project>


### PR DESCRIPTION
This pull request adds LICENSE.txt and THIRD_PARTY_LICENSE.txt to META-INF directory in each jar.
All modules in this project share the same LICENSE.txt which locates at the root directory of this project.
Each module has its own THIRD_PARTY_LICENSE.txt which locates at the base directory of the module.
