### PR TITLE
add META-INF/services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,14 @@
         </includes>
         <targetPath>META-INF</targetPath>
       </resource>
+      <!-- Add META-INF/services -->
+      <resource>
+        <directory>${project.basedir}/src/main/resources/META-INF/services/</directory>
+        <includes>
+          <include>oracle.jdbc.spi.*</include>
+        </includes>
+        <targetPath>META-INF/services/</targetPath>
+      </resource>
     </resources>
   </build>
 </project>


### PR DESCRIPTION
The META-INF/services would not be picked up by maven automatically after adding the `<resources></resources>` section. Added an entry in the resources section of pom.xml to include the files in META-INF/services when building the artifacts.