### PR TITLE
Update oci sdk version

### DIFF
--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>3.2.2</version>
+        <version>3.23.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -67,7 +67,6 @@
     <dependency>
       <groupId>com.oracle.database.security</groupId>
       <artifactId>oraclepki</artifactId>
-      <version>23.3.0.23.09</version>
       <scope>test</scope>
     </dependency>
 

--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>3.23.1</version>
+        <version>3.28.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- Update the version of oci-java-sdk to 3.28.1:

  The SBOM scan report showed the following issue:
  OCI Java SDK - [CVE-2023-33201] CWE-295: Improper Certificate Validation
    pkg:maven/com.oracle.database.jdbc/ojdbc-provider-oci@1.0.0
      pkg:maven/com.oracle.oci.sdk/oci-java-sdk-common@3.2.2
        pkg:maven/org.bouncycastle/bcprov-jdk15on@1.70
  This issue in BouncyCastle is fixed versions: BC 1.74 but OCI Java SDK 3.2.2 consumes 1.70.
  
  OCI SDK 3.28.1 consumes BC 1.74. So it looks like we should upgrade the OCI SDK from 3.2.2 to 3.28.1.

- Removes the version tag of oraclepki in ojdbc-provider-oci/pom.xml. The dependency oraclepki should reuse the version which is inherited from the parent pom and avoid specifying its own in the pom file.