### PR TITLE
Set oci-java-sdk-common-httpclient-jersey as Runtime Dependency

### DIFF
--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common-httpclient-jersey</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.security</groupId>


### PR DESCRIPTION
The extension set oci-java-sdk-common-httpclient-jersey as a compile dependency, which should be set as a runtime dependency instead. 

More details below:
Starting from OCI Java SDK 3.x.x, users have to explicitly choose the http provider in their application, otherwise they will get the error message: `No http provider available; add dependency on one of the oci-java-sdk-common-httpclient-* choices, e.g. oci-java-sdk-common-httpclient-jersey.`

The extension selects oci-java-sdk-common-httpclient-jersey as the http provider so that the users don't have to worry if the http provider is not configured. Users can override the dependency with their own choice later in their pom file. 