### PR TITLE
Accept db tools conn with proxy authentication

### DIFF
--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -57,6 +57,9 @@ JDBC URL Sample that uses the OCI DBTools provider:
 jdbc:oracle:thin:@config-ocidbtools:ocid1.databasetoolsconnection.oc1.phx.ama ...
 </pre>
 
+Provider can now accept Database Tools Connections with Proxy Authentication,
+only if username is provided in Proxy Authentication Info, without the password and roles.
+
 ## OCI Object Storage Config Provider
 The Oracle DataSource uses a new prefix `jdbc:oracle:thin:@config-ociobject:` to be able to identify that the configuration parameters should be loaded using OCI Object Storage. Users only need to indicate the URL Path of the Object containing the JSON payload, with the following syntax:
 

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -57,7 +57,7 @@ JDBC URL Sample that uses the OCI DBTools provider:
 jdbc:oracle:thin:@config-ocidbtools:ocid1.databasetoolsconnection.oc1.phx.ama ...
 </pre>
 
-Provider can now accept Database Tools Connections with Proxy Authentication,
+Provider can now support Database Tools Connections with Proxy Authentication,
 only if username is provided in Proxy Authentication Info, without the password and roles.
 
 ## OCI Object Storage Config Provider

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -1,6 +1,17 @@
 package oracle.jdbc.provider.oci.configuration;
 
-import com.oracle.bmc.databasetools.model.*;
+import com.oracle.bmc.databasetools.model.DatabaseToolsConnection;
+import com.oracle.bmc.databasetools.model.DatabaseToolsConnectionOracleDatabase;
+import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStore;
+import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStoreContent;
+import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStoreContentSecretId;
+import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStorePassword;
+import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStorePasswordSecretId;
+import com.oracle.bmc.databasetools.model.DatabaseToolsUserPassword;
+import com.oracle.bmc.databasetools.model.DatabaseToolsUserPasswordSecretId;
+import com.oracle.bmc.databasetools.model.LifecycleState;
+import com.oracle.bmc.databasetools.model.DatabaseToolsConnectionOracleDatabaseProxyClient;
+import com.oracle.bmc.databasetools.model.DatabaseToolsConnectionOracleDatabaseProxyClientUserName;
 import com.oracle.bmc.model.BmcException;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.provider.oci.databasetools.DatabaseToolsConnectionFactory;

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -1,15 +1,6 @@
 package oracle.jdbc.provider.oci.configuration;
 
-import com.oracle.bmc.databasetools.model.DatabaseToolsConnection;
-import com.oracle.bmc.databasetools.model.DatabaseToolsConnectionOracleDatabase;
-import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStore;
-import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStoreContent;
-import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStoreContentSecretId;
-import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStorePassword;
-import com.oracle.bmc.databasetools.model.DatabaseToolsKeyStorePasswordSecretId;
-import com.oracle.bmc.databasetools.model.DatabaseToolsUserPassword;
-import com.oracle.bmc.databasetools.model.DatabaseToolsUserPasswordSecretId;
-import com.oracle.bmc.databasetools.model.LifecycleState;
+import com.oracle.bmc.databasetools.model.*;
 import com.oracle.bmc.model.BmcException;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.provider.oci.databasetools.DatabaseToolsConnectionFactory;
@@ -193,6 +184,23 @@ public class OciDatabaseToolsConnectionProvider
     Map<String, String> advancedProps = connection.getAdvancedProperties();
     if (advancedProps != null)
       properties.putAll(connection.getAdvancedProperties());
+
+    /* check if database tools connection has proxy client info */
+    DatabaseToolsConnectionOracleDatabaseProxyClient proxyClient =
+      connection.getProxyClient();
+
+    if (proxyClient instanceof DatabaseToolsConnectionOracleDatabaseProxyClientUserName) {
+      DatabaseToolsConnectionOracleDatabaseProxyClientUserName proxyClientUserName =
+        (DatabaseToolsConnectionOracleDatabaseProxyClientUserName) proxyClient;
+
+      /* check if proxyClient has password or roles */
+      if (proxyClientUserName.getUserPassword() != null || proxyClientUserName.getRoles() != null) {
+        throw new UnsupportedOperationException("Unsupported feature: the " +
+          "proxyClient of this database tools connection has user password or" +
+          "roles");
+      }
+      properties.put(OracleConnection.CONNECTION_PROPERTY_PROXY_CLIENT_NAME, proxyClientUserName.getUserName());
+    }
 
     return properties;
   }

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/configuration/OciDatabaseToolsConnectionProvider.java
@@ -206,9 +206,9 @@ public class OciDatabaseToolsConnectionProvider
 
       /* check if proxyClient has password or roles */
       if (proxyClientUserName.getUserPassword() != null || proxyClientUserName.getRoles() != null) {
-        throw new UnsupportedOperationException("Unsupported feature: the " +
-          "proxyClient of this database tools connection has user password or" +
-          "roles");
+        throw new UnsupportedOperationException(
+          "Unsupported feature: the proxyClient of this database tools " +
+            "connection has user password or roles");
       }
       properties.put(OracleConnection.CONNECTION_PROPERTY_PROXY_CLIENT_NAME, proxyClientUserName.getUserName());
     }


### PR DESCRIPTION
In this upload, the provider can accept db tools connection with proxy authentication, only if username is set in proxy authentication, without password or roles.

Specifically, according to [OCI docs](https://docs.oracle.com/en-us/iaas/tools/java/3.29.0/com/oracle/bmc/databasetools/model/DatabaseToolsConnectionOracleDatabaseProxyClient.html), 
`DatabaseToolsConnectionOracleDatabaseProxyClient` has two direct known subclasses,
which is `DatabaseToolsConnectionOracleDatabaseProxyClientNoProxy`, and 
`DatabaseToolsConnectionOracleDatabaseProxyClientUserName`.

If a db tools connection with proxy authentication is given, we can retrieve proxy authentication info from `proxyClientUserName`. Otherwise, we will get `proxyClientNoProxy`.
Username is retrieved here and added to properties of the Connection. If retrieved password or roles are not null, an exception will be thrown.

Also README is updated in oci.

Please take a look.