### PR TITLE
Set Release to JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,28 @@
     <java.version>8</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.release>${java.version}</maven.compiler.release>
     <jdbc.version>23.3.0.23.09</jdbc.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.11.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
+
+  <!--
+    This profile configures the "release" option for javac, which was added
+    in JDK 9. See https://github.com/oracle-samples/ojdbc-extensions/pull/46
+  -->
+  <profiles>
+    <profile>
+      <id>javac-release</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+      </properties>
+    </profile>
+  </profiles>
 
   <modules>
     <module>ojdbc-provider-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,10 @@
   </scm>
 
   <properties>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.source>8</maven.compiler.source>
+    <java.version>8</java.version>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <jdbc.version>23.3.0.23.09</jdbc.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.11.0</mockito.version>


### PR DESCRIPTION
This branch sets the maven.compiler.release setting to 8. This avoids sneaky runtime failures that can happen when a new JDK version is compiling our code. For instance, calls to CharBuffer.clear() break if compiled by a JDK newer than 8, and then run on JDK 8. This is because the return type of the clear() method changed after JDK 8, and our users will hit:
```
java.lang.NoSuchMethodError: java.nio.CharBuffer.clear()Ljava/nio/CharBuffer;
	at oracle.jdbc.provider.oci.vault.Secret.toCharArray(Secret.java:99)
```
Setting the release option ensures that byte code is consistent with the API of the specified JDK 8. With this CharBuffer example, it ensures that byte code calls a method with a `Buffer` return type, rather than `CharBuffer`. 
The release option is documented here: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html