### PR TITLE
38 multi region support in oci

### DIFF
--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/Ocid.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/Ocid.java
@@ -19,10 +19,10 @@ public final class Ocid {
   private final Region region;
 
   /** The regular expression of ocid */
-  private static final String regex = "ocid1\\.[^.]+\\.[^.]+\\.([^.]*)\\..+";
+  private static final String REGEX = "ocid1\\.[^.]+\\.[^.]+\\.([^.]*)\\..+";
 
   /** The pattern of ocid */
-  private static final Pattern pattern = Pattern.compile(regex);
+  private static final Pattern PATTERN = Pattern.compile(REGEX);
 
   public Ocid(String content) {
     this.content = content;
@@ -41,7 +41,7 @@ public final class Ocid {
    * @return an {@code Region} which is extracted from the ocid string
    **/
   private static Region parseRegion(String content) {
-    Matcher matcher = pattern.matcher(content);
+    Matcher matcher = PATTERN.matcher(content);
     if (matcher.matches()) {
       String regionCode = matcher.group(1);
       if (regionCode.equals("")) {

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/Ocid.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/Ocid.java
@@ -1,0 +1,59 @@
+package oracle.jdbc.provider.oci;
+
+import com.oracle.bmc.Region;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a general OCID class, which contains an ocid string as its
+ * content. It parses out a region from the provided ocid string during
+ * construction.
+ *
+ * Fields:
+ * - String content: The full ocid as a string.
+ * - Region region: The parsed region extracted from the ocid string.
+ **/
+public class Ocid {
+  private String content;
+  private Region region;
+
+  public Ocid(String content) {
+    this.content = content;
+    this.region = parseRegion();
+  }
+
+  /**
+   * Returns a {@link Region} which is parsed from the ocid string. If
+   * the region part is empty. The method will return null instead of
+   * throwing an exception.
+   * The format of Oracle Cloud ID (OCID) is documented as follows:
+   * <pre>
+   * ocid1.<RESOURCE TYPE>.<REALM>.[REGION][.FUTURE USE].<UNIQUE ID>
+   * </pre>
+   * @see <a href="https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm">Resource Identifiers</a>
+   * @return an {@code Region} which is extracted from the ocid string
+   **/
+  private Region parseRegion(){
+    String regex = "ocid1\\.[^.]+\\.[^.]+\\.([^.]*)\\..+";
+    Pattern pattern = Pattern.compile(regex);
+    Matcher matcher = pattern.matcher(content);
+    if (matcher.matches()) {
+      String regionCode = matcher.group(1);
+      if (regionCode.equals("")) {
+        return null;
+      }
+      return Region.fromRegionCode(matcher.group(1));
+    }
+    throw new IllegalStateException(
+      "Fail to parse region from the OCID: " + content);
+  }
+
+  public Region getRegion() {
+    return region;
+  }
+
+  public String getContent() {
+    return content;
+  }
+}

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/Ocid.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/Ocid.java
@@ -6,21 +6,27 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Represents a general OCID class, which contains an ocid string as its
- * content. It parses out a region from the provided ocid string during
- * construction.
- *
- * Fields:
- * - String content: The full ocid as a string.
- * - Region region: The parsed region extracted from the ocid string.
+ * Represents a general Oracle Cloud ID (OCID) class, which contains an
+ * ocid string as its content. It parses out a region from the provided
+ * ocid string during construction.
  **/
-public class Ocid {
-  private String content;
-  private Region region;
+public final class Ocid {
+
+  /** The ocid string */
+  private final String content;
+
+  /** The parsed region extracted from the ocid string */
+  private final Region region;
+
+  /** The regular expression of ocid */
+  private static final String regex = "ocid1\\.[^.]+\\.[^.]+\\.([^.]*)\\..+";
+
+  /** The pattern of ocid */
+  private static final Pattern pattern = Pattern.compile(regex);
 
   public Ocid(String content) {
     this.content = content;
-    this.region = parseRegion();
+    this.region = parseRegion(content);
   }
 
   /**
@@ -34,9 +40,7 @@ public class Ocid {
    * @see <a href="https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm">Resource Identifiers</a>
    * @return an {@code Region} which is extracted from the ocid string
    **/
-  private Region parseRegion(){
-    String regex = "ocid1\\.[^.]+\\.[^.]+\\.([^.]*)\\..+";
-    Pattern pattern = Pattern.compile(regex);
+  private static Region parseRegion(String content) {
     Matcher matcher = pattern.matcher(content);
     if (matcher.matches()) {
       String regionCode = matcher.group(1);

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/databasetools/DatabaseToolsConnectionFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/databasetools/DatabaseToolsConnectionFactory.java
@@ -45,6 +45,7 @@ import com.oracle.bmc.databasetools.responses.GetDatabaseToolsConnectionResponse
 import oracle.jdbc.provider.factory.Resource;
 import oracle.jdbc.provider.factory.ResourceFactory;
 import oracle.jdbc.provider.oci.OciResourceFactory;
+import oracle.jdbc.provider.oci.Ocid;
 import oracle.jdbc.provider.parameter.Parameter;
 import oracle.jdbc.provider.parameter.ParameterSet;
 
@@ -97,15 +98,22 @@ public class DatabaseToolsConnectionFactory extends
     AbstractAuthenticationDetailsProvider authenticationDetails,
     ParameterSet parameterSet) {
     String connectionOcid = parameterSet.getRequired(CONNECTION_OCID);
+    Ocid ocid = new Ocid(connectionOcid);
+    if (ocid.getRegion() == null) {
+      throw new IllegalStateException(
+        "Fail to get region from Database Tools Connection OCID: "
+          + ocid.getContent());
+    }
 
     try (DatabaseToolsClient client =
         DatabaseToolsClient.builder().build(authenticationDetails)) {
+      client.setRegion(ocid.getRegion());
 
       GetDatabaseToolsConnectionResponse getResponse = client
           .getDatabaseToolsConnection(
               GetDatabaseToolsConnectionRequest
                   .builder()
-                  .databaseToolsConnectionId(connectionOcid)
+                  .databaseToolsConnectionId(ocid.getContent())
                   .build());
 
       return Resource.createPermanentResource(

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/databasetools/DatabaseToolsConnectionFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/databasetools/DatabaseToolsConnectionFactory.java
@@ -99,9 +99,11 @@ public class DatabaseToolsConnectionFactory extends
     ParameterSet parameterSet) {
     String connectionOcid = parameterSet.getRequired(CONNECTION_OCID);
     Ocid ocid = new Ocid(connectionOcid);
+
+    // Ensure parsed region is not null to prevent failure in sending request
     if (ocid.getRegion() == null) {
       throw new IllegalStateException(
-        "Fail to get region from Database Tools Connection OCID: "
+        "Region is missing in Database Tools Connection OCID: "
           + ocid.getContent());
     }
 

--- a/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/vault/SecretFactory.java
+++ b/ojdbc-provider-oci/src/main/java/oracle/jdbc/provider/oci/vault/SecretFactory.java
@@ -95,7 +95,6 @@ public final class SecretFactory extends OciResourceFactory<Secret> {
       ParameterSet parameterSet) {
 
     String secretOcid = parameterSet.getRequired(OCID);
-    //parseRegion(ocid);
     Ocid ocid = new Ocid(secretOcid);
 
     // Ensure parsed region is not null to prevent failure in sending request


### PR DESCRIPTION
In this upload, a new Class Ocid is created. We can use the constructor to create an Ocid object:
`Ocid ocid = new Ocid(ocidString);`

And retrieve ocid string using `ocid.getContent()`,
retrieve region using `ocid.getRegion().`

The parser in Class Ocid parse the region from string ocid. This region can be empty, considering that in some cases, an ocid string does not represent regional resources.

In this upload, database tools connection and secret are using the new Ocid Class to parse region and set region to resolve multi region issue. (Recall multi region issue: there is region 'us-XXX-1' in profile, but we want to support resources in other regions, without changing the profile)
When building the client to send request, the region of client is set by
`client.setRegion(ocid.getRegion)`

Please take a look.