### PR TITLE
Maven Compiler Plugin 3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,28 @@
     <java.version>8</java.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.release>${java.version}</maven.compiler.release>
     <jdbc.version>23.3.0.23.09</jdbc.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.11.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
+
+  <!--
+    This profile configures the "release" option for javac, which was added
+    in JDK 9. See https://github.com/oracle-samples/ojdbc-extensions/pull/46
+  -->
+  <profiles>
+    <profile>
+      <id>javac-release</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+      </properties>
+    </profile>
+  </profiles>
 
   <modules>
     <module>ojdbc-provider-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,10 @@
   </scm>
 
   <properties>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.source>8</maven.compiler.source>
+    <java.version>8</java.version>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <jdbc.version>23.3.0.23.09</jdbc.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.11.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,8 @@
   </scm>
 
   <properties>
-    <java.version>8</java.version>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <jdbc.version>23.3.0.23.09</jdbc.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.11.0</mockito.version>
@@ -40,18 +39,18 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
-  <!--
-    This profile configures the "release" option for javac, which was added
-    in JDK 9. See https://github.com/oracle-samples/ojdbc-extensions/pull/46
-  -->
   <profiles>
+    <!--
+      This profile configures the "release" option for javac, which was added
+      in JDK 9. See https://github.com/oracle-samples/ojdbc-extensions/pull/46
+    -->
     <profile>
       <id>javac-release</id>
       <activation>
         <jdk>[9,)</jdk>
       </activation>
       <properties>
-        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
       </properties>
     </profile>
   </profiles>
@@ -106,6 +105,11 @@
   </dependencyManagement>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This branch sets the Maven Compiler Plugin to version 3.11.0.

This branch is a follow up to https://github.com/oracle-samples/ojdbc-extensions/pull/46, which configured Maven with a release option for javac. It seems that this configuration is not be supported with older versions of the compiler plugin, such as 3.6. The latest version is 3.11, so I've updated to that.

I also reverted changes to Maven's source and target properties, setting them as "1.8" rather than "8". All examples I see in Maven documentation use "1.8" for these properties. However, examples will also use "8" for the release property, so I think the same JDK version needs to expressed differently, depending on which property is being set.
