### PR TITLE
upgrade Azure and OCI SDKs

### DIFF
--- a/ojdbc-provider-azure/pom.xml
+++ b/ojdbc-provider-azure/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-sdk-bom</artifactId>
-        <version>1.2.17</version>
+        <version>1.2.19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/ojdbc-provider-oci/pom.xml
+++ b/ojdbc-provider-oci/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>3.28.1</version>
+        <version>3.30.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
For the next release (v1.0.1), upgrade Azure and OCI JDKs to latest versions:

- azure-sdk-bom from 1.2.17 to `1.2.19` ([ojdbc-extensions](https://github.com/oracle-samples/ojdbc-extensions/tree/main)/[ojdbc-provider-azure](https://github.com/oracle-samples/ojdbc-extensions/tree/main/ojdbc-provider-azure)
/pom.xml) 
  `1.2.19` will also address the new vulnerability CVE-2023-34054.
- oci-java-sdk-bom from 3.28.1 to `3.30.0`