### PR TITLE
Updating JavaDoc links to 23

### DIFF
--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -53,7 +53,7 @@ There are 3 fixed values that are looked at by the provider in the retrieved con
 - user (optional)
 - password (optional)
 
-The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs that are with sub-prefix `/jdbc` will be applied to a DataSource. The key values are constant keys which are equivalent to the properties defined in the [OracleConnection](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html) interface.
+The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs that are with sub-prefix `/jdbc` will be applied to a DataSource. The key values are constant keys which are equivalent to the properties defined in the [OracleConnection](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html) interface.
 
 For example, let's suppose an url like:
 
@@ -191,7 +191,7 @@ Specifies the scope of databases that may be accessed with the token. See
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-token.properties](example-token.properties).
 
@@ -251,7 +251,7 @@ Any valid secret name is accepted.
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-vault.properties](example-key-vault.properties).
 
@@ -296,7 +296,7 @@ Any valid secret name is accepted.
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-vault.properties](example-key-vault.properties).
 
@@ -491,7 +491,7 @@ oracle.jdbc.provider.accessToken.clientId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 oracle.jdbc.provider.accessToken.clientCertificatePath=/users/app/certificate.pem
 ```
 Connection properties which identify and configure a provider may appear in a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 or be configured programmatically. Configuration with JVM system properties is
 not supported.
 

--- a/ojdbc-provider-azure/example-key-vault.properties
+++ b/ojdbc-provider-azure/example-key-vault.properties
@@ -41,7 +41,7 @@
 #
 # This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
 # connection property. For details, see:
-# https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
 
 # Configures the Azure Key Vault Username Provider. The vault URL and secret name
 # are configured as an environment variables or JVM system properties

--- a/ojdbc-provider-azure/example-token.properties
+++ b/ojdbc-provider-azure/example-token.properties
@@ -41,7 +41,7 @@
 #
 # This file can be located by Oracle JDBC using the "oracle.jdbc.config.file"
 # connection property. For details, see:
-# https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
+# https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE
 
 # Configures the Azure OAUTH Token Provider. The application ID URI of the
 # database is configured as an environment variables or JVM system properties

--- a/ojdbc-provider-oci/README.md
+++ b/ojdbc-provider-oci/README.md
@@ -77,7 +77,7 @@ There are 3 fixed values that are looked at the root level.
 - user (optional)
 - password (optional)
 
-The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs that are with sub-prefix `/jdbc` will be applied to a DataSource. The key values are constant keys which are equivalent to the properties defined in the [OracleConnection](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html) interface.
+The rest are dependent on the driver, in our case `/jdbc`. The key-value pairs that are with sub-prefix `/jdbc` will be applied to a DataSource. The key values are constant keys which are equivalent to the properties defined in the [OracleConnection](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html) interface.
 
 For example, let's suppose an url like:
 
@@ -247,7 +247,7 @@ MEDIUM
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-adb.properties](example-adb.properties).
 
@@ -284,7 +284,7 @@ of an Autonomous Database
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-adb.properties](example-adb.properties).
 
@@ -318,7 +318,7 @@ of an OCI Vault secret
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-vault.properties](example-vault.properties).
 
@@ -352,7 +352,7 @@ of an OCI Vault secret
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-vault.properties](example-vault.properties).
 
@@ -394,7 +394,7 @@ urn:oracle:db::id::*
 </table>
 
 An example of a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 that configures this provider can be found in
 [example-token.properties](example-token.properties).
 
@@ -507,7 +507,7 @@ oracle.jdbc.provider.accessToken.configFile=/home/app/resources/oci-config
 oracle.jdbc.provider.accessToken.profile=APP_PROFILE
 ```
 Connection properties which identify and configure a provider may appear in a
-[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
+[connection properties file](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_CONFIG_FILE)
 or be configured programmatically. Configuration with JVM system properties is
 not supported.
 


### PR DESCRIPTION
This branch updates URL links to the Oracle JDBC JavaDoc. These links appear in README's and in example connection property files. Some links were going to the OJDBC 21.x release. These are now updated to the 23.x release.