### PR TITLE
Redirect URI is Optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ out/
 # "example-"
 **/*.properties
 !**/example-*.properties
+
+# Vim
+**/*.swp

--- a/ojdbc-provider-azure/README.md
+++ b/ojdbc-provider-azure/README.md
@@ -134,8 +134,7 @@ The user can provide an optional parameter `AUTHENTICATION` (case-ignored) which
   <td rowspan="2"><b>AZURE_INTERACTIVE</b></td>
   <td rowspan="2">InteractiveBrowserCredential</td>
   <td><b>AZURE_CLIENT_ID</b></td>
-  <td>&nbsp;</td></tr>
-  <tr><td><b>AZURE_REDIRECT_URL</b></td>
+  <td><b>AZURE_REDIRECT_URL</b></td>
 </tr>
 </tbody>
 </table>
@@ -446,18 +445,17 @@ common set of parameters.
       <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url">
       Redirect URL
       </a>
-      for `authentication-method=interactive`
+      for <code>authentication-method=interactive</code>
       </td>
       <td>
-      A URL of the form <code>http://localhost:{port-number}</code> is accepted.
+      A URL of the form <code>http://localhost[:port-number]</code> is accepted.
       <td>
       <i>
-        No default value. If interactive authentication is used, a value must 
-        be configured for this parameter.
+        <code>http://localhost</code>
+        (redirects to any available port in the ephemeral range)
       </i>
       </td>
     </tr>
-    
   </tbody>
 </table>
 

--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/authentication/TokenCredentialFactory.java
@@ -108,7 +108,7 @@ public final class TokenCredentialFactory
 
   /**
    * Redirect URL registered with Azure Active Directory. This parameter is
-   * required for {@link AzureAuthenticationMethod#INTERACTIVE} authentication
+   * optional for {@link AzureAuthenticationMethod#INTERACTIVE} authentication
    * in a web browser.
    */
   public static final Parameter<String> REDIRECT_URL = Parameter.create();
@@ -210,7 +210,7 @@ public final class TokenCredentialFactory
     ParameterSet parameterSet) {
     return new InteractiveBrowserCredentialBuilder()
       .clientId(parameterSet.getOptional(CLIENT_ID))
-      .redirectUrl(parameterSet.getRequired(REDIRECT_URL))
+      .redirectUrl(parameterSet.getOptional(REDIRECT_URL))
       .build();
   }
 


### PR DESCRIPTION
This branch changes the redirect URI parameter for interactive authentication with Azure. The parameter is now optional. If users do not configure this parameter, the Azure SDK for Java will use a localhost URL having any available port number in the ephemeral range. For example, the SDK might use `http://localhost:52741`.

This change eases the burden of configuration for our users. They will no longer need to configure a redirect URI, on top of all the other configurable values. Users only need to add a localhost URI in their Azure App Registration, and it will match with a localhost URI having any port number used by clients (https://learn.microsoft.com/en-us/entra/identity-platform/reply-url#localhost-exceptions)