### PR TITLE
add Azure Vault Provider

### DIFF
--- a/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultURLParser.java
+++ b/ojdbc-provider-azure/src/main/java/oracle/jdbc/provider/azure/configuration/AzureVaultURLParser.java
@@ -40,67 +40,54 @@ package oracle.jdbc.provider.azure.configuration;
 
 import com.azure.core.util.UrlBuilder;
 import oracle.jdbc.provider.azure.keyvault.KeyVaultSecretFactory;
-import oracle.jdbc.spi.OracleConfigurationJsonSecretProvider;
-import oracle.jdbc.provider.configuration.JsonSecretUtil;
-import oracle.jdbc.provider.parameter.ParameterSet;
 import oracle.jdbc.provider.parameter.ParameterSetBuilder;
 import oracle.jdbc.provider.parameter.ParameterSetParser;
-import oracle.sql.json.OracleJsonObject;
-
-import java.util.Base64;
-
-import static oracle.jdbc.provider.azure.configuration.AzureVaultURLParser.PARAMETER_SET_PARSER;
 
 /**
- * A provider of Secret values from Azure Key Vault.
+ * A URL parser used by {@link AzureVaultSecretProvider} and {@link AzureVaultJsonProvider}.
  */
-public final class AzureVaultSecretProvider
-    implements OracleConfigurationJsonSecretProvider {
+public class AzureVaultURLParser {
+  /**
+   * Parser that recognizes the "value" field and parses it as a Key Vault
+   * secret URL.
+   * {@link AzureConfigurationParameters#configureBuilder(ParameterSetParser.Builder)}
+   * configures the parser to recognize fields of the nested JSON object named
+   * "authentication".
+   */
+  public static final ParameterSetParser PARAMETER_SET_PARSER =
+    AzureConfigurationParameters.configureBuilder(ParameterSetParser.builder()
+        .addParameter("value", AzureVaultURLParser::parseVaultSecretUri))
+      .build();
 
   /**
-   * {@inheritDoc}
-   * <p>
-   *   Returns the password of the Secret that is retrieved from Azure Key Vault.
-   * </p><p>
-   *   The {@code secretJsonObject} has the following form:
-   * </p><pre>{@code
-   *   "password": {
-   *       "type": "vault-azure",
-   *       "value": "https://myvault.vault.azure.net/secrets/mysecret",
-   *       "authentication": {
-   *           "method": "AZURE_DEFAULT"
-   *       }
-   *   }
-   * }</pre>
-   *
-   * @param secretJsonObject json object to be parsed
-   * @return encoded char array in base64 format that represents the retrieved
-   *         Secret.
+   * Parses the "value" field of a JSON object as a vault URI with the path
+   * of a named secret. An example URI is:
+   * <pre>
+   * https://mykeyvaultpfs.vault.azure.net/secrets/mySecret2
+   * </pre>
+   * This parser configures the given {@code builder} with two distinct
+   * parameters accepted by {@link KeyVaultSecretFactory}: One parameter for the
+   * vault URL, and another for the secret name.
+   * @param vaultSecretUri Vault Secret URI which contains the path of a secret.
+   *                      Not null.
+   * @param builder Builder to configure with parsed parameters. Not null.
    */
-  @Override
-  public char[] getSecret(OracleJsonObject secretJsonObject) {
+  private static void parseVaultSecretUri(
+    String vaultSecretUri, ParameterSetBuilder builder) {
 
-    ParameterSet parameterSet =
-      PARAMETER_SET_PARSER.parseNamedValues(
-        JsonSecretUtil.toNamedValues(secretJsonObject));
+    UrlBuilder urlBuilder = UrlBuilder.parse(vaultSecretUri);
 
-    String secretString = KeyVaultSecretFactory.getInstance()
-      .request(parameterSet)
-      .getContent()
-      .getValue();
+    String vaultUrl = "https://" + urlBuilder.getHost();
+    builder.add("value", KeyVaultSecretFactory.VAULT_URL, vaultUrl);
 
-    return Base64.getEncoder()
-      .encodeToString(secretString.getBytes())
-      .toCharArray();
-  }
+    String path = urlBuilder.getPath();
 
-  /**
-   * {@inheritDoc}
-   *
-   * @return secret type. Not null.
-   */
-  @Override
-  public String getSecretType() {
-    return "vault-azure";
+    if (!path.contains("/secrets"))
+      throw new IllegalArgumentException("The Vault Secret URI should " +
+        "contain \"/secrets\" following by the name of the Secret: " +
+        vaultSecretUri);
+
+    String secretName = path.replace("/secrets", "");
+    builder.add("value", KeyVaultSecretFactory.SECRET_NAME, secretName);
   }
 }

--- a/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.OracleConfigurationProvider
+++ b/ojdbc-provider-azure/src/main/resources/META-INF/services/oracle.jdbc.spi.OracleConfigurationProvider
@@ -1,1 +1,2 @@
 oracle.jdbc.provider.azure.configuration.AzureAppConfigurationProvider
+oracle.jdbc.provider.azure.configuration.AzureVaultJsonProvider


### PR DESCRIPTION
First upload of OCI Vault Provider.

A new utility class `AzureVaultURLParser` is added and I move the variable `PARAMETER_SET_PARSER` and method `parseVaultSecretUri` from `AzureVaultSecretProvider` to this new class. The reason is that I think I can reuse the code to parse secret URL not only in `AzureVaultSecretProvider`, but also in the new `AzureVaultJsonProvider`.

The `getJson` in `AzureVaultJsonProvider` takes in String secretIdentifier and return the payload stored in secret value.

The size limit of a secret in azure vault is 25 KB.
According to [Azure docs - About Azure Key Vault secrets](https://learn.microsoft.com/en-us/azure/key-vault/secrets/about-secrets)
"Internally, Key Vault stores and manages secrets as sequences of octets (8-bit bytes), with a maximum size of 25k bytes each."

Similar to prefix in OCI Vault case,
The prefix is now `config-vaultazure`.
The regular expression in driver code is `@config-(\\w*):(.*)`.
If we want hyphen in between, which is `config-vault-azure`
The regular expression can be changed to `@config-(\\w+(-\\w+)*|):(.*)`.

Please take a look.